### PR TITLE
Add PFN logo

### DIFF
--- a/src/components/home/home.scss
+++ b/src/components/home/home.scss
@@ -205,8 +205,9 @@
     
         &__item {
             float: left;
+            position: relative;
             width: 25%;
-            padding: 30px 0;
+            height: 152px;
             text-align: center;
             background-color: #fff;
             border-right: 1px solid #eeeeee;
@@ -218,9 +219,12 @@
             }
     
             img {
-                width: 196px;
-                height: 91px;
+                max-height: 92;
                 max-width: 80%;
+                top: 50%;
+                left: 50%;
+                position: absolute;
+                transform: translate(-50%, -50%)
             }
         }
     }    

--- a/src/components/home/home.tsx
+++ b/src/components/home/home.tsx
@@ -4,8 +4,20 @@ import * as React from 'react';
 import { PROJECTS } from '../projects';
 
 const argoWheelImg = require('../../assets/images/argo-wheel.png');
-const logos = ['intuit.png', 'blackrock.png', 'google.png', 'nvidia.png', 'datadog.png', 'cyrus.png', 'gladly.png', 'corefilling.png', 'adoby.png', 'interline.png', 'pfn.png'].map(
-    (name) => ({ name, src: require(`../../assets/images/logos/${name}`)}));
+const communities = {
+  'intuit.png': 'https://www.intuit.com/',
+  'blackrock.png': 'https://www.blackrock.com/',
+  'google.png': 'https://www.google.com/intl/en/about/our-company/',
+  'nvidia.png': 'https://www.nvidia.com/',
+  'datadog.png': 'https://www.datadoghq.com/',
+  'cyrus.png': 'https://cyrusbio.com/',
+  'gladly.png': 'https://gladly.com/',
+  'corefilling.png': 'https://www.corefiling.com/',
+  'adoby.png': 'https://www.adobe.com/',
+  'interline.png': 'https://www.interline.io/blog/scaling-openstreetmap-data-workflows/',
+  'pfn.png': 'https://preferred-networks.jp/en/',
+};
+const logos = Object.keys(communities).map((name, index) => ({ name, src: require(`../../assets/images/logos/${name}`), href: communities[name]}));
 
 require('./home.scss');
 
@@ -41,7 +53,9 @@ export const Home = () => (
                 <div className='home__community-logos'>
                     {logos.map((item) => (
                         <div key={item.name} className='home__community-logos__item'>
-                            <img src={item.src} alt={item.name}/>
+                            <a href={item.href} target='_blank'>
+                              <img src={item.src} alt={item.name}/>
+                            </a>
                         </div>
                     ))}
                 </div>

--- a/src/components/home/home.tsx
+++ b/src/components/home/home.tsx
@@ -4,7 +4,7 @@ import * as React from 'react';
 import { PROJECTS } from '../projects';
 
 const argoWheelImg = require('../../assets/images/argo-wheel.png');
-const logos = ['intuit.png', 'blackrock.png', 'google.png', 'nvidia.png', 'datadog.png', 'cyrus.png', 'gladly.png', 'corefilling.png', 'adoby.png', 'interline.png'].map(
+const logos = ['intuit.png', 'blackrock.png', 'google.png', 'nvidia.png', 'datadog.png', 'cyrus.png', 'gladly.png', 'corefilling.png', 'adoby.png', 'interline.png', 'pfn.png'].map(
     (name) => ({ name, src: require(`../../assets/images/logos/${name}`)}));
 
 require('./home.scss');


### PR DESCRIPTION
@alexmt I added my company's logo in the community section and made the following 2 changes for all logos in the section to make them better look and usability.
- Keep the ratio of the original logo images
- Add links of each community members based on the [Who uses Argo?](https://github.com/argoproj/argo#who-uses-argo) of the GitHub README.

<img width="1066" alt="screen shot 2019-02-02 at 1 07 26 am" src="https://user-images.githubusercontent.com/1162120/52135269-c0966400-2688-11e9-91a3-c6b509a2e72d.png">

Could you consider merging this change and update the official page?