### PR TITLE
Resolve dependency vulnerability from marked package

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "gatsby-transformer-remark": "^1.7.44",
     "gh-pages": "^1.2.0",
     "jsdom": "^12.0.0",
-    "marked": "^0.5.1",
+    "marked": "^0.7.0",
     "querystring": "^0.2.0",
     "raw-loader": "^0.5.1",
     "react": "^16.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6198,9 +6198,10 @@ markdown-table@^1.1.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/markdown-table/-/markdown-table-1.1.2.tgz#c78db948fa879903a41bce522e3b96f801c63786"
 
-marked@^0.5.1:
-  version "0.5.1"
-  resolved "https://registry.yarnpkg.com/marked/-/marked-0.5.1.tgz#062f43b88b02ee80901e8e8d8e6a620ddb3aa752"
+marked@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-0.7.0.tgz#b64201f051d271b1edc10a04d1ae9b74bb8e5c0e"
+  integrity sha512-c+yYdCZJQrsRjTPhUx7VKkApw9bwDkNbHUKo1ovgcfDjb2kc8rLuRbIFyXL5WOEUwzSSKo3IXpph2K6DqB/KZg==
 
 math-expression-evaluator@^1.2.14:
   version "1.2.17"


### PR DESCRIPTION
Hi friends,
The package `marked` had a Regular Expression Denial of Service vulnerability up until version 0.7.0. Upgrading the version requirement in this package doesn't cause any issues with the site.
More info on the ReDoS vulnerability in `marked`: https://snyk.io/vuln/SNYK-JS-MARKED-451341