### PR TITLE
chore: Use "Rollouts" instead of "Advanced Deployment Controller"

### DIFF
--- a/src/components/projects.ts
+++ b/src/components/projects.ts
@@ -15,8 +15,8 @@ export const PROJECTS: {[name: string]: { name: string, title: string; keywords:
     },
     'argo-rollouts': {
         name: 'Argo Rollouts',
-        title: 'Advanced Deployment Controller',
-        description: ' Additional Kubernetes deployment strategies such as Blue-Green and Canary.',
+        title: 'Rollouts',
+        description: 'Additional Kubernetes deployment strategies such as Blue-Green and Canary.',
         link: '/argo-rollouts',
         keywords: ['gitops', 'continuous-delivery', 'blue-green', 'canary', 'kubernetes'],
     },


### PR DESCRIPTION
Rollouts should have name recognition by now