### PR TITLE
fix: Fix URL to USERS.md for Argo Workflows repo

### DIFF
--- a/scripts/logos.sh
+++ b/scripts/logos.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 
-ARGO_URL=https://raw.githubusercontent.com/argoproj/argo/master/USERS.md
+ARGOWF_URL=https://raw.githubusercontent.com/argoproj/argo-workflows/master/USERS.md
 ARGOCD_URL=https://raw.githubusercontent.com/argoproj/argo-cd/master/USERS.md
 # Users who requested to avoid adding logos
 BLACKLIST=("www.ea.com")
 
-for url in $({ curl -s $ARGO_URL && curl -s $ARGOCD_URL; } | grep -Eo '(http|https)://[^/"]+' |  cut -d ")" -f1  | awk -F/ '{print $3}' | sort | uniq)
+for url in $({ curl -s $ARGOWF_URL && curl -s $ARGOCD_URL; } | grep -Eo '(http|https)://[^/"]+' |  cut -d ")" -f1  | awk -F/ '{print $3}' | sort | uniq)
 do
     if [[ " ${BLACKLIST[@]} " =~ "$url" ]]; then
         >&2 echo "Logo for $url is blacklisted"


### PR DESCRIPTION
The current URL https://raw.githubusercontent.com/argoproj/argo/master/USERS.md returns 404.

Signed-off-by: terrytangyuan <terrytangyuan@gmail.com>