### PR TITLE
docs: Add missing maintainers that have logos in the repo

### DIFF
--- a/src/components/maintainers.js
+++ b/src/components/maintainers.js
@@ -9,7 +9,7 @@ const Maintainers = () => {
         allMarkdownRemark(
           filter: {
             fileAbsolutePath: {
-              regex: "/(members/codefresh|intuit|blackrock|redhat)/"
+              regex: "/(members/codefresh|intuit|blackrock|redhat|alibaba|antgroup|preferred)/"
             }
           }
           sort: { order: ASC, fields: frontmatter___title }

--- a/src/components/maintainers.js
+++ b/src/components/maintainers.js
@@ -9,7 +9,7 @@ const Maintainers = () => {
         allMarkdownRemark(
           filter: {
             fileAbsolutePath: {
-              regex: "/(members/codefresh|intuit|blackrock|redhat|alibaba|antgroup|preferred)/"
+              regex: "/(members/codefresh|intuit|blackrock|redhat|alibaba|antgroup)/"
             }
           }
           sort: { order: ASC, fields: frontmatter___title }


### PR DESCRIPTION
Based on https://github.com/argoproj/argoproj/blob/master/MAINTAINERS.md. There are two others that do not have logos on the repo yet and thus not included in this PR.

Signed-off-by: Yuan Tang <terrytangyuan@gmail.com>