### PR TITLE
Google analytics ID cleanup

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -57,7 +57,7 @@ module.exports = {
     {
       resolve: "gatsby-plugin-google-gtag",
       options: {
-        trackingIds: ["G-5Z1VTPDL73", "UA-105170809-1"],
+        trackingIds: ["G-5Z1VTPDL73"],
         gtagConfig: {
           anonymize_ip: true,
         },


### PR DESCRIPTION
- Closes #118 
  We no longer need to explicitly list the UA ID since it is [connected] from the GA4 ID.

/cc @alexmt @alexec 

[connected]: https://support.google.com/analytics/answer/9973999