### PR TITLE
chore: update argo-workflows docs links to readthedocs

### DIFF
--- a/content/pages/workflows/index.mdx
+++ b/content/pages/workflows/index.mdx
@@ -5,8 +5,8 @@ description: "Kubernetes-native workflow engine supporting DAG and step-based wo
 image: workflows.png
 thumbnail: workflows-thumbnail.png
 repo: argo-workflows
-docs: https://argoproj.github.io/argo-workflows
-quickstart: https://argoproj.github.io/argo-workflows/quick-start
+docs: https://argo-workflows.readthedocs.io/en/latest/
+quickstart: https://argo-workflows.readthedocs.io/en/latest/quick-start/
 ---
 
 ## What is Argo Workflows?


### PR DESCRIPTION
With https://github.com/argoproj/argo-workflows/pull/12360 we have moved argo-workflows docs to readthedocs.  We are redirecting from the previous github pages but this will ensure going straight to the docs