### PR TITLE
chore: remove BlackRock from corporate maintainers

### DIFF
--- a/src/components/maintainers.js
+++ b/src/components/maintainers.js
@@ -9,7 +9,7 @@ const Maintainers = () => {
         allMarkdownRemark(
           filter: {
             fileAbsolutePath: {
-              regex: "/(members/codefresh|intuit|blackrock|redhat|akuity)/"
+              regex: "/(members/codefresh|intuit|redhat|akuity)/"
             }
           }
           sort: { order: ASC, fields: frontmatter___title }


### PR DESCRIPTION
Follow-up to [Slack thread in `#argo-maintainers`](https://cloud-native.slack.com/archives/C022F03E6BD/p1709312792925719?thread_ts=1709267157.329689&cid=C022F03E6BD) and yesterday's [Argoproj Maintainers Meeting](https://docs.google.com/document/d/1C71GA0XCxsyGP7Q4SYveHak5ZZcJOuaOiDCt_xHG10U/edit#heading=h.aywjjtr02vuf) and [Workflows Contributor Meeting](https://docs.google.com/document/d/1tznN5LB-KrNkC6dmeIzpKfuyvZWgCJpRuS-E84zseC8/edit#heading=h.swznvez1n6cr)

### Motivation

- BlackRock has not contributed in some time
  - they had a Lead on Events who has not contributed in enough time that they were moved to Alumni in the [Maintainers list](https://github.com/argoproj/argoproj/blob/fd0748186cac552b4a89228a541c9c855e4434cf/MAINTAINERS.md?plain=1#L71) in https://github.com/argoproj/argoproj/pull/257
    - therefore, BlackRock has no active maintainers
    - note that [per the membership requirements](https://github.com/argoproj/argoproj/blob/fd0748186cac552b4a89228a541c9c855e4434cf/community/membership.md?plain=1#L246), this was measured by no activity for at least 1 year prior and no membership has been re-requested since (it's roughly ~6 months since removal at this time)
  
### Modifications

Remove `blackrock` from the `maintainers.js` regex

### Historical Context

I don't know the history too well, but BlackRock had donated the entire Argo Events project originally. Here are [some](https://www.intuit.com/blog/news-social/cloud-native-computing-foundation-accepts-argo-as-an-incubator-project/)  [historical](https://www.cncf.io/blog/2020/04/07/toc-welcomes-argo-into-the-cncf-incubator/) [links](https://www.forbes.com/sites/janakirammsv/2020/04/19/argo-and-dragonfly-become-incubating-projects-at-the-cncf/?sh=58cd24954e56) I could find about that.
They do not seem to currently contribute to it though.