### PR TITLE
docs: use yarn install instead of npm install

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ Repository for Argo website at [argoproj.io](https://argoproj.io).
 
 ## Run and deploy
 
-* Install nodejs, yarn, npm
-* Run `npm install`
+* Install nodejs, yarn
+* Run `yarn install`
 * Start local dev server using `yarn start` and check web site at http://localhost:8000
 
 * To push changes to http://argoproj.io/ make sure you have write access to `https://github.com/argoproj/argo-site.git`


### PR DESCRIPTION
The GitHub workflow uses yarn install, so the docs should too.