### PR TITLE
fix: page overflow caused by nav

### DIFF
--- a/src/components/nav.js
+++ b/src/components/nav.js
@@ -46,11 +46,13 @@ const Nav = ({ isOpen, color }) => {
     }
   }, [])
 
-  const navClass = classNames({
-    "absolute z-998 -right-full top-0 w-4/6 h-screen pt-14 bg-white overflow-y-scroll transition-right duration-300 in-expo shadow-2xl": true,
+   const navClass = classNames({
+    "absolute z-998 top-0 w-4/6 h-screen pt-14 bg-white overflow-y-scroll transition-right duration-300 in-expo shadow-2xl": true,
+    "right-full": !isOpen,
     "lg:items-center lg:ml-auto lg:flex lg:space-x-8 lg:relative lg:right-auto lg:top-auto lg:w-auto lg:h-auto lg:pt-0 lg:bg-none lg:bg-transparent lg:overflow-y-visible lg:shadow-none": true,
     "!right-0": isOpen,
   })
+
 
   return (
     <nav ref={targetRef} className={navClass}>


### PR DESCRIPTION
- Remove "right-full" class from true state to prevent overflow on page load
- Apply "right-full" class when the nav is not currently open (`!isOpen`)

## Note:
After fixing the nav position I noticed that after opening it, the nav slides from the left to the right side. Please let me know if this intended or should be fixed. 