### PR TITLE
Rename argo-contributors slack channel

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -18,7 +18,7 @@ module.exports = {
           {name: "argo-sig-ui", link: "https://cloud-native.slack.com/archives/C01TR44A8NB"},
           {name: "argo-cd-autopilot", link: "https://cloud-native.slack.com/archives/C0207C47D0X"},
           {name: "argo-cd-image-updater", link: "https://cloud-native.slack.com/archives/C0296T47CHY"},
-          {name: "argo-contributors", link: "https://app.slack.com/client/T08PSQ7BQ/C020XM04CUW"},
+          {name: "argo-cd-contributors", link: "https://app.slack.com/client/T08PSQ7BQ/C020XM04CUW"},
           {name: "argo-announcements", link: "https://app.slack.com/client/T08PSQ7BQ/C02165G1L48"},
           {name: "argo-helm-charts", link: "https://app.slack.com/client/T08PSQ7BQ/C02097VUKUM"},
         ]


### PR DESCRIPTION
## Why this PR?

The `argo-contributors` slack channel was renamed to `argo-cd-contributors` back in 2024. But we're still using the old name.

<img width="720" height="301" alt="Screenshot 2025-11-13 at 3 05 08 PM" src="https://github.com/user-attachments/assets/39dbd803-5c98-49a8-8506-ef394090fcb3" />

## What's new?

- rename `argo-contributors` slack channel to `argo-cd-contributors`.
