### PR TITLE
fix: Use Readthedocs versioned website for Rollout documentation

### DIFF
--- a/content/pages/rollouts/index.mdx
+++ b/content/pages/rollouts/index.mdx
@@ -5,8 +5,8 @@ description: "Advanced Kubernetes deployment strategies such as Canary and Blue-
 image: rollouts.png
 thumbnail: rollouts-thumbnail.png
 repo: argo-rollouts
-docs: https://argoproj.github.io/argo-rollouts
-quickstart: https://argoproj.github.io/argo-rollouts/getting-started
+docs: https://argo-rollouts.readthedocs.io
+quickstart: https://argo-rollouts.readthedocs.io/en/stable/getting-started/
 ---
 
 ## What is Argo Rollouts?


### PR DESCRIPTION
As per https://github.com/argoproj/argo-rollouts/issues/3287 the main Argo Website should link to readthedocs which is versioned documentation and not the old GitHub pages which will soon be removed.